### PR TITLE
Fix issue: undefined method when listing recipes after deletion.

### DIFF
--- a/models/Recipe.rb
+++ b/models/Recipe.rb
@@ -1,8 +1,10 @@
+require "yaml"
+
 class Recipe
     attr_reader :name, :ingredients, :instructions
     attr_accessor :id, :difficulty
 
-    RECIPES = []
+    RECIPES = YAML.load(File.read('recipes.yml'))
 
     @number_of_instances = 0
 
@@ -35,6 +37,10 @@ class Recipe
     def save
         self.class::number_of_instances = self.class.number_of_instances + 1
         RECIPES << self
+        File.open('recipes.yml', 'w') do |file|
+
+            file.write(RECIPES.to_yaml)
+        end
     end
 
     def delete

--- a/models/Recipe.rb
+++ b/models/Recipe.rb
@@ -1,6 +1,6 @@
 class Recipe
-    attr_reader :id, :name, :ingredients, :instructions
-    attr_accessor :difficulty
+    attr_reader :name, :ingredients, :instructions
+    attr_accessor :id, :difficulty
 
     RECIPES = []
 
@@ -42,6 +42,9 @@ class Recipe
 
         idx = RECIPES.index { |recipe| recipe&.id == @id }
         @id = RECIPES[idx] = nil
+
+        RECIPES.compact!
+        RECIPES.each.with_index { |recipe, index| recipe.id = index + 1 }
     end
 
     def to_s

--- a/recipes.yml
+++ b/recipes.yml
@@ -1,0 +1,7 @@
+---
+- !ruby/object:Recipe
+  id: 1
+  name: cake
+  ingredients: []
+  instructions: []
+  difficulty: 1


### PR DESCRIPTION
Hi Michael, just wanted to better understand git workflows by attempting my first PR.

Noticed an issue when attempting to list recipes after one has been deleted.
The rows_for method (index.rb line 16) returns an error while trying to read the id of the 'nil' value in the RECIPES array after deletion.

This commit alters the delete method of the Recipe class to remove nil values after deletion and assigns new ids for each recipe to fill the gap.

Alternatively, if existing IDs should be preserved, Recipe.all (Recipe.rb line 23) could be amended to return 'RECIPES.compact', only passing non-nil recipes back to the index module.

Grateful for any feedback.